### PR TITLE
Add Jest tests for vectorizeEmotion

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
        consistent behaviour across browsers.  Without this library
        the machine learning enhancements below would not function. -->
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@3.21.0/dist/tf.min.js"></script>
+    <script src="vectorizeEmotion.js"></script>
   <style>
     body {
       background: #111;
@@ -2418,14 +2419,6 @@
       emotionVocab.forEach((w, i) => { emotionVocabIndex[w] = i; });
     })();
     // Convert a sentence into a binary vector over the emotion vocabulary.
-    function vectorizeEmotion(text) {
-      const vec = new Array(emotionVocab.length).fill(0);
-      text.toLowerCase().replace(/[.,!?]/g, ' ').split(/\s+/).forEach(tok => {
-        const idx = emotionVocabIndex[tok];
-        if (idx !== undefined) vec[idx] = 1;
-      });
-      return vec;
-    }
     // Build the training dataset for the emotion model.
     const emotionTrainX = [];
     const emotionTrainY = [];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "egomorph-",
+  "version": "1.0.0",
+  "description": "Eine emotionale KI für den Browser: erkennt Gefühle, passt ihre Persönlichkeit an, spricht, hört zu und lernt aus deinem Feedback – komplett offline mit TensorFlow.js.",
+  "main": "ego_settings.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/vectorizeEmotion.test.js
+++ b/tests/vectorizeEmotion.test.js
@@ -1,0 +1,17 @@
+const { vectorizeEmotion } = require('../vectorizeEmotion');
+
+describe('vectorizeEmotion', () => {
+  const vocab = ['hallo', 'welt', 'ich', 'fuehle'];
+  const vocabIndex = {};
+  vocab.forEach((w, i) => { vocabIndex[w] = i; });
+
+  test('marks known words in vector', () => {
+    const vec = vectorizeEmotion('Hallo Welt!', vocab, vocabIndex);
+    expect(vec).toEqual([1, 1, 0, 0]);
+  });
+
+  test('ignores unknown words', () => {
+    const vec = vectorizeEmotion('Unbekanntes Wort', vocab, vocabIndex);
+    expect(vec).toEqual([0, 0, 0, 0]);
+  });
+});

--- a/vectorizeEmotion.js
+++ b/vectorizeEmotion.js
@@ -1,0 +1,20 @@
+(function(root, factory){
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(root);
+  } else {
+    root.vectorizeEmotion = factory(root).vectorizeEmotion;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(root){
+  function vectorizeEmotion(text, vocab, vocabIndex) {
+    const vocabulary = vocab || root.emotionVocab || [];
+    const index = vocabIndex || root.emotionVocabIndex || {};
+    const vec = new Array(vocabulary.length).fill(0);
+    text.toLowerCase().replace(/[.,!?]/g, ' ').split(/\s+/).forEach(tok => {
+      if (!tok) return;
+      const idx = index[tok];
+      if (idx !== undefined) vec[idx] = 1;
+    });
+    return vec;
+  }
+  return { vectorizeEmotion };
+});


### PR DESCRIPTION
## Summary
- extract emotion vectorization into reusable `vectorizeEmotion.js`
- add Jest unit tests confirming vocabulary words activate vector positions
- configure Jest as dev dependency and test script

## Testing
- `npm test` *(fails: jest not found; package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689f2c742a9c8324a4c8f68768d132c2