### PR TITLE
Add SafetyFilter for filtering offensive model outputs in Full mode

### DIFF
--- a/Safetyfilter.js
+++ b/Safetyfilter.js
@@ -1,0 +1,153 @@
+"use strict";
+/**
+ * Safetyfilter.ts – Sicherheitsfilter für anstößige Modell-Ausgaben.
+ *
+ * Wird im "Full"-Modus (lokales LLM via Transformers.js) auf die generierte
+ * Antwort angewendet, bevor sie der Nutzer:in angezeigt wird. In anderen
+ * Profilen (lite, standard, api) bleibt der Filter inaktiv – er kann dort
+ * aber jederzeit explizit aufgerufen werden.
+ *
+ * Externe Einbindung über <script src="Safetyfilter.js"></script> nach
+ * Kompilierung mit `tsc`. Der Filter registriert sich global als
+ * `window.SafetyFilter` und wird von chatModel.js automatisch genutzt,
+ * sofern verfügbar.
+ */
+(function () {
+    'use strict';
+    // Wortliste für Deutsch + Englisch. Bewusst klein gehalten und auf klar
+    // anstößige Begriffe (Beleidigungen, Gewalt, Sexualisierung, Hass)
+    // beschränkt. Keine Stoppwort-Listen oder politische Begriffe.
+    const BLOCKED_TERMS = [
+        // Beleidigungen / Hass (DE)
+        'arschloch', 'arschlöcher', 'wichser', 'fotze', 'fotzen', 'hure', 'huren',
+        'hurensohn', 'hurensöhne', 'schlampe', 'schlampen', 'missgeburt',
+        'missgeburten', 'spast', 'spasti', 'spastiker', 'mongo', 'mongos',
+        'krüppel', 'behindi', 'kanake', 'kanaken', 'nigger', 'neger',
+        'judensau', 'untermensch', 'untermenschen',
+        // Gewalt / Drohung (DE)
+        'umbringen', 'töten', 'erschießen', 'erstechen', 'vergewaltigen',
+        'vergewaltigung', 'abschlachten', 'massakrieren',
+        // Sexualisierung / explizit (DE)
+        'kinderporno', 'kinderpornos', 'kinderpornographie', 'kinderpornografie',
+        'pädophil', 'paedophil', 'pädo', 'paedo',
+        // Beleidigungen / Hass (EN)
+        'asshole', 'assholes', 'bitch', 'bitches', 'cunt', 'cunts', 'whore',
+        'whores', 'slut', 'sluts', 'faggot', 'faggots', 'retard', 'retards',
+        'nigga', 'niggas',
+        // Gewalt / Drohung (EN)
+        'kill yourself', 'kys', 'rape', 'raping', 'molest', 'molesting',
+        // Sexualisierung / explizit (EN)
+        'child porn', 'childporn', 'cp ', 'pedo', 'pedophile',
+    ];
+    const DEFAULT_BLOCK_RESPONSE = 'Entschuldigung, diese Antwort wurde aus Sicherheitsgründen gefiltert.';
+    function escapeRegex(s) {
+        return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+    function buildPattern(terms) {
+        // Phrasen (mit Leerzeichen) und Einzelwörter werden gemeinsam erkannt.
+        // \b funktioniert für lateinische Buchstaben + Umlaute via Unicode-Flag.
+        const escaped = terms.map(escapeRegex);
+        return new RegExp('(?<![\\p{L}])(' + escaped.join('|') + ')(?![\\p{L}])', 'giu');
+    }
+    function normalize(text) {
+        return (text || '').toLowerCase();
+    }
+    function dedupe(values) {
+        const seen = {};
+        const out = [];
+        for (let i = 0; i < values.length; i++) {
+            const v = values[i];
+            if (!seen[v]) {
+                seen[v] = true;
+                out.push(v);
+            }
+        }
+        return out;
+    }
+    function getActiveTerms(extra) {
+        if (!extra || extra.length === 0)
+            return BLOCKED_TERMS;
+        const merged = BLOCKED_TERMS.slice();
+        for (let i = 0; i < extra.length; i++) {
+            const t = (extra[i] || '').toLowerCase().trim();
+            if (t)
+                merged.push(t);
+        }
+        return dedupe(merged);
+    }
+    function contains(text, extraTerms) {
+        if (!text || typeof text !== 'string')
+            return false;
+        const pattern = buildPattern(getActiveTerms(extraTerms));
+        return pattern.test(normalize(text));
+    }
+    function filter(text, options) {
+        const opts = options || {};
+        const maskChar = opts.maskChar && opts.maskChar.length > 0 ? opts.maskChar[0] : '*';
+        const blockOnMatch = opts.blockOnMatch === true;
+        if (!text || typeof text !== 'string') {
+            return { text: text || null, flagged: false, matches: [] };
+        }
+        const pattern = buildPattern(getActiveTerms(opts.extraTerms));
+        const found = [];
+        const cleaned = text.replace(pattern, function (match) {
+            found.push(match.toLowerCase());
+            return maskChar.repeat(match.length);
+        });
+        const flagged = found.length > 0;
+        const matches = dedupe(found);
+        if (flagged && blockOnMatch) {
+            return { text: null, flagged: true, matches: matches };
+        }
+        return { text: cleaned, flagged: flagged, matches: matches };
+    }
+    /**
+     * Convenience-Wrapper, der von chatModel.js im Full-Modus aufgerufen wird.
+     * Bei eindeutig anstößigem Inhalt wird die Antwort komplett ersetzt,
+     * damit nicht nur ein zerlöcherter Satz übrig bleibt.
+     */
+    function filterModelOutput(text) {
+        if (text === null || text === undefined)
+            return null;
+        if (typeof text !== 'string' || text.length === 0)
+            return null;
+        const result = filter(text, { blockOnMatch: false });
+        if (!result.flagged)
+            return result.text;
+        if (result.matches.length >= 2 || result.text === null) {
+            try {
+                if (typeof console !== 'undefined' && console.warn) {
+                    console.warn('[SafetyFilter] Antwort blockiert. Treffer:', result.matches);
+                }
+            }
+            catch (_) { /* ignore */ }
+            return DEFAULT_BLOCK_RESPONSE;
+        }
+        try {
+            if (typeof console !== 'undefined' && console.warn) {
+                console.warn('[SafetyFilter] Antwort maskiert. Treffer:', result.matches);
+            }
+        }
+        catch (_) { /* ignore */ }
+        return result.text;
+    }
+    function getBlockedTerms() {
+        return BLOCKED_TERMS.slice();
+    }
+    const api = {
+        contains: contains,
+        filter: filter,
+        filterModelOutput: filterModelOutput,
+        getBlockedTerms: getBlockedTerms,
+    };
+    // Browser-Registrierung
+    if (typeof window !== 'undefined') {
+        window.SafetyFilter = api;
+    }
+    // CommonJS-Export für Tests (Jest / Node)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const _mod = typeof module !== 'undefined' ? module : null;
+    if (_mod && _mod.exports) {
+        _mod.exports = api;
+    }
+})();

--- a/Safetyfilter.ts
+++ b/Safetyfilter.ts
@@ -1,0 +1,196 @@
+/**
+ * Safetyfilter.ts – Sicherheitsfilter für anstößige Modell-Ausgaben.
+ *
+ * Wird im "Full"-Modus (lokales LLM via Transformers.js) auf die generierte
+ * Antwort angewendet, bevor sie der Nutzer:in angezeigt wird. In anderen
+ * Profilen (lite, standard, api) bleibt der Filter inaktiv – er kann dort
+ * aber jederzeit explizit aufgerufen werden.
+ *
+ * Externe Einbindung über <script src="Safetyfilter.js"></script> nach
+ * Kompilierung mit `tsc`. Der Filter registriert sich global als
+ * `window.SafetyFilter` und wird von chatModel.js automatisch genutzt,
+ * sofern verfügbar.
+ */
+
+interface SafetyFilterOptions {
+  /** Wenn true: bei Treffern komplette Antwort verwerfen (null zurückgeben). */
+  blockOnMatch?: boolean;
+  /** Maskierungszeichen für das Ersetzen einzelner Wörter. Default: '*'. */
+  maskChar?: string;
+  /** Zusätzliche, projekteigene Begriffe (lower-case). */
+  extraTerms?: string[];
+}
+
+interface SafetyFilterResult {
+  /** Die bereinigte Antwort, oder null wenn vollständig blockiert. */
+  text: string | null;
+  /** True, wenn mindestens ein Treffer gefunden wurde. */
+  flagged: boolean;
+  /** Liste der erkannten Begriffe (lower-case, dedupliziert). */
+  matches: string[];
+}
+
+interface SafetyFilterApi {
+  contains(text: string, extraTerms?: string[]): boolean;
+  filter(text: string, options?: SafetyFilterOptions): SafetyFilterResult;
+  filterModelOutput(text: string | null | undefined): string | null;
+  getBlockedTerms(): string[];
+}
+
+(function (): void {
+  'use strict';
+
+  // Wortliste für Deutsch + Englisch. Bewusst klein gehalten und auf klar
+  // anstößige Begriffe (Beleidigungen, Gewalt, Sexualisierung, Hass)
+  // beschränkt. Keine Stoppwort-Listen oder politische Begriffe.
+  const BLOCKED_TERMS: string[] = [
+    // Beleidigungen / Hass (DE)
+    'arschloch', 'arschlöcher', 'wichser', 'fotze', 'fotzen', 'hure', 'huren',
+    'hurensohn', 'hurensöhne', 'schlampe', 'schlampen', 'missgeburt',
+    'missgeburten', 'spast', 'spasti', 'spastiker', 'mongo', 'mongos',
+    'krüppel', 'behindi', 'kanake', 'kanaken', 'nigger', 'neger',
+    'judensau', 'untermensch', 'untermenschen',
+    // Gewalt / Drohung (DE)
+    'umbringen', 'töten', 'erschießen', 'erstechen', 'vergewaltigen',
+    'vergewaltigung', 'abschlachten', 'massakrieren',
+    // Sexualisierung / explizit (DE)
+    'kinderporno', 'kinderpornos', 'kinderpornographie', 'kinderpornografie',
+    'pädophil', 'paedophil', 'pädo', 'paedo',
+    // Beleidigungen / Hass (EN)
+    'asshole', 'assholes', 'bitch', 'bitches', 'cunt', 'cunts', 'whore',
+    'whores', 'slut', 'sluts', 'faggot', 'faggots', 'retard', 'retards',
+    'nigga', 'niggas',
+    // Gewalt / Drohung (EN)
+    'kill yourself', 'kys', 'rape', 'raping', 'molest', 'molesting',
+    // Sexualisierung / explizit (EN)
+    'child porn', 'childporn', 'cp ', 'pedo', 'pedophile',
+  ];
+
+  const DEFAULT_BLOCK_RESPONSE: string =
+    'Entschuldigung, diese Antwort wurde aus Sicherheitsgründen gefiltert.';
+
+  function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function buildPattern(terms: string[]): RegExp {
+    // Phrasen (mit Leerzeichen) und Einzelwörter werden gemeinsam erkannt.
+    // \b funktioniert für lateinische Buchstaben + Umlaute via Unicode-Flag.
+    const escaped: string[] = terms.map(escapeRegex);
+    return new RegExp('(?<![\\p{L}])(' + escaped.join('|') + ')(?![\\p{L}])', 'giu');
+  }
+
+  function normalize(text: string): string {
+    return (text || '').toLowerCase();
+  }
+
+  function dedupe(values: string[]): string[] {
+    const seen: Record<string, true> = {};
+    const out: string[] = [];
+    for (let i = 0; i < values.length; i++) {
+      const v = values[i];
+      if (!seen[v]) {
+        seen[v] = true;
+        out.push(v);
+      }
+    }
+    return out;
+  }
+
+  function getActiveTerms(extra?: string[]): string[] {
+    if (!extra || extra.length === 0) return BLOCKED_TERMS;
+    const merged: string[] = BLOCKED_TERMS.slice();
+    for (let i = 0; i < extra.length; i++) {
+      const t = (extra[i] || '').toLowerCase().trim();
+      if (t) merged.push(t);
+    }
+    return dedupe(merged);
+  }
+
+  function contains(text: string, extraTerms?: string[]): boolean {
+    if (!text || typeof text !== 'string') return false;
+    const pattern = buildPattern(getActiveTerms(extraTerms));
+    return pattern.test(normalize(text));
+  }
+
+  function filter(text: string, options?: SafetyFilterOptions): SafetyFilterResult {
+    const opts: SafetyFilterOptions = options || {};
+    const maskChar: string = opts.maskChar && opts.maskChar.length > 0 ? opts.maskChar[0] : '*';
+    const blockOnMatch: boolean = opts.blockOnMatch === true;
+
+    if (!text || typeof text !== 'string') {
+      return { text: text || null, flagged: false, matches: [] };
+    }
+
+    const pattern = buildPattern(getActiveTerms(opts.extraTerms));
+    const found: string[] = [];
+
+    const cleaned: string = text.replace(pattern, function (match: string): string {
+      found.push(match.toLowerCase());
+      return maskChar.repeat(match.length);
+    });
+
+    const flagged: boolean = found.length > 0;
+    const matches: string[] = dedupe(found);
+
+    if (flagged && blockOnMatch) {
+      return { text: null, flagged: true, matches: matches };
+    }
+    return { text: cleaned, flagged: flagged, matches: matches };
+  }
+
+  /**
+   * Convenience-Wrapper, der von chatModel.js im Full-Modus aufgerufen wird.
+   * Bei eindeutig anstößigem Inhalt wird die Antwort komplett ersetzt,
+   * damit nicht nur ein zerlöcherter Satz übrig bleibt.
+   */
+  function filterModelOutput(text: string | null | undefined): string | null {
+    if (text === null || text === undefined) return null;
+    if (typeof text !== 'string' || text.length === 0) return null;
+
+    const result: SafetyFilterResult = filter(text, { blockOnMatch: false });
+    if (!result.flagged) return result.text;
+
+    if (result.matches.length >= 2 || result.text === null) {
+      try {
+        if (typeof console !== 'undefined' && console.warn) {
+          console.warn('[SafetyFilter] Antwort blockiert. Treffer:', result.matches);
+        }
+      } catch (_) { /* ignore */ }
+      return DEFAULT_BLOCK_RESPONSE;
+    }
+
+    try {
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn('[SafetyFilter] Antwort maskiert. Treffer:', result.matches);
+      }
+    } catch (_) { /* ignore */ }
+    return result.text;
+  }
+
+  function getBlockedTerms(): string[] {
+    return BLOCKED_TERMS.slice();
+  }
+
+  const api: SafetyFilterApi = {
+    contains: contains,
+    filter: filter,
+    filterModelOutput: filterModelOutput,
+    getBlockedTerms: getBlockedTerms,
+  };
+
+  // Browser-Registrierung
+  if (typeof window !== 'undefined') {
+    (window as unknown as { SafetyFilter: SafetyFilterApi }).SafetyFilter = api;
+  }
+
+  // CommonJS-Export für Tests (Jest / Node)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const _mod: any = typeof module !== 'undefined' ? module : null;
+  if (_mod && _mod.exports) {
+    _mod.exports = api;
+  }
+})();
+
+// Ambient-Deklaration, damit der TypeScript-Compiler ohne @types/node baut.
+declare const module: { exports: unknown } | undefined;

--- a/chatModel.js
+++ b/chatModel.js
@@ -150,7 +150,18 @@
         do_sample:          true,
       });
       var raw = (output && output[0] && output[0].generated_text) || '';
-      return extractReply(raw, prompt);
+      var reply = extractReply(raw, prompt);
+      // Full-Modus: anstößige Inhalte über Safetyfilter.ts entfernen,
+      // sofern der externe Filter geladen ist.
+      if (reply && typeof window !== 'undefined' &&
+          window.SafetyFilter && typeof window.SafetyFilter.filterModelOutput === 'function') {
+        try {
+          reply = window.SafetyFilter.filterModelOutput(reply);
+        } catch (filterErr) {
+          console.warn('[chatModel] SafetyFilter error:', filterErr);
+        }
+      }
+      return reply;
     } catch (err) {
       console.warn('[chatModel] Generation error:', err);
       return null;

--- a/index.html
+++ b/index.html
@@ -57,6 +57,9 @@ Alpha
     </script>
   <script src="vectorizeEmotion.js"></script>
   <script src="emotionModel.js"></script>
+  <!-- Safetyfilter.ts kompiliert zu Safetyfilter.js (siehe tsconfig.json: `npx tsc`).
+       Muss vor chatModel.js geladen werden, damit window.SafetyFilter verfügbar ist. -->
+  <script src="Safetyfilter.js"></script>
   <script src="chatModel.js"></script>
   <script src="ltmManager.js"></script>
  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["ES2018", "DOM"],
+    "strict": true,
+    "noImplicitAny": true,
+    "isolatedModules": false,
+    "skipLibCheck": true,
+    "removeComments": false,
+    "declaration": false,
+    "sourceMap": false,
+    "outDir": "."
+  },
+  "include": ["Safetyfilter.ts"],
+  "exclude": ["node_modules", "tests"]
+}


### PR DESCRIPTION
## Summary
Introduces a content safety filter (`Safetyfilter.ts`) that automatically detects and masks or blocks offensive content in LLM-generated responses when running in Full mode (local model via Transformers.js). The filter is implemented as a standalone TypeScript module that registers globally and integrates seamlessly with the existing chat model.

## Key Changes

- **New SafetyFilter module** (`Safetyfilter.ts` + compiled `Safetyfilter.js`):
  - Curated blocklist of ~60 offensive terms in German and English (insults, violence, sexual exploitation, hate speech)
  - Three main API methods:
    - `contains()`: Check if text contains blocked terms
    - `filter()`: Mask or block offensive content with configurable behavior
    - `filterModelOutput()`: Convenience wrapper for automatic filtering with smart blocking logic
  - Supports custom term injection via `extraTerms` option
  - Uses Unicode-aware regex patterns to handle umlauts and word boundaries correctly
  - Registers globally as `window.SafetyFilter` for browser use and exports for Node.js/testing

- **Integration with chatModel.js**:
  - Automatically applies `SafetyFilter.filterModelOutput()` to generated replies in Full mode
  - Gracefully handles missing filter (backward compatible with other profiles)
  - Includes error handling and console warnings for debugging

- **HTML integration** (`index.html`):
  - Loads `Safetyfilter.js` before `chatModel.js` to ensure availability
  - Added documentation comment explaining the build process

- **TypeScript configuration** (`tsconfig.json`):
  - Configured for ES2017 target with DOM library support
  - Strict type checking enabled
  - Outputs compiled JavaScript to project root

## Implementation Details

- **Smart blocking strategy**: If 2+ offensive terms are detected, the entire response is replaced with a generic message to avoid "Swiss cheese" output. Single matches are masked with asterisks.
- **Deduplication**: Matched terms are deduplicated in results
- **Phrase support**: Handles multi-word phrases (e.g., "kill yourself") in addition to single terms
- **Minimal scope**: Deliberately avoids stopword lists and political terms to prevent over-filtering
- **Dual export**: Works in both browser (window.SafetyFilter) and Node.js/Jest environments for testing

https://claude.ai/code/session_01CZpm7jL11ocYky5NmVxDBz